### PR TITLE
Fix Android and iOS Cordova build

### DIFF
--- a/packages/vue-component-dev-client/client/dev-client.js
+++ b/packages/vue-component-dev-client/client/dev-client.js
@@ -85,7 +85,7 @@ Meteor.startup(function() {
   // Dev client
   let port = window.__hot_port__ || 3003;
   console.log('[HMR] Dev client port', port);
-  let _socket = require('socket.io-client')(`http://localhost:${port}`);
+  let _socket = require('socket.io-client')(`${Meteor.absoluteUrl().replace(/:\d+\//gi, '')}:${port}`);
   window.__dev_client__ = _socket;
 
   _socket.on('connect', function() {

--- a/packages/vue-component-dev-client/package.js
+++ b/packages/vue-component-dev-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-component-dev-client',
-  version: '0.2.1',
+  version: '0.2.2',
   summary: 'Hot-reloading client for vue components',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md',

--- a/packages/vue-component-dev-server/package.js
+++ b/packages/vue-component-dev-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-component-dev-server',
-  version: '0.0.2',
+  version: '0.0.3',
   summary: 'Dev server for vue hot-reloading',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md',

--- a/packages/vue-component-dev-server/server/main.js
+++ b/packages/vue-component-dev-server/server/main.js
@@ -1,5 +1,5 @@
 function getMeteorPort() {
-  const reg = /:\/\/localhost:(\d+)/gi;
+  const reg = /:\/\/.+:(\d+)/gi;
   const result = reg.exec(Meteor.absoluteUrl());
   if(result.length >= 2) {
     return parseInt(result[1]) + 3;


### PR DESCRIPTION
Hello, thank you very much for your package.

I believe these changes will resolve #60 and #62.

In order to successfully test on android or ios you will need to run meteor like this
```bash
ROOT_URL=http://${server ip}:${server port}; meteor run android-device ios-device --mobile-server=http://${server ip}:${server port}
```

The reason for this is because the cordova build needs to connect to the server. If the above env vars are not set, the cordova build will look for the server at localhost which will refer to the cordova build and not the server.

With these changes I have successfully tested on an Android device and iOS simulator