### PR TITLE
Use Meteor runtime config instead of a custom variable

### DIFF
--- a/packages/vue-component-dev-client/client/dev-client.js
+++ b/packages/vue-component-dev-client/client/dev-client.js
@@ -83,7 +83,7 @@ if(!Response.prototype.setEncoding) {
 
 Meteor.startup(function() {
   // Dev client
-  let port = window.__hot_port__ || 3003;
+  let port = __meteor_runtime_config__.VUE_DEV_SERVER_PORT || 3003;
   console.log('[HMR] Dev client port', port);
   let _socket = require('socket.io-client')(`${Meteor.absoluteUrl().replace(/:\d+\//gi, '')}:${port}`);
   window.__dev_client__ = _socket;

--- a/packages/vue-component-dev-server/server/main.js
+++ b/packages/vue-component-dev-server/server/main.js
@@ -9,6 +9,4 @@ function getMeteorPort() {
 const PORT = parseInt(process.env.HMR_PORT) || parseInt(process.env.VUE_DEV_SERVER_PORT) || getMeteorPort() || 3003;
 
 // Client-side config
-WebAppInternals.addStaticJs(`
-  window.__hot_port__ = ${PORT};
-`);
+__meteor_runtime_config__.VUE_DEV_SERVER_PORT = PORT;


### PR DESCRIPTION
Simply cleaner. It also supports [CSP](https://en.wikipedia.org/wiki/Content_Security_Policy) out of the box (if one wants to test it in development, though).