### PR TITLE
Be careful about process.stdout.clearLine not existing

### DIFF
--- a/packages/vue-component/plugin/dev-server.js
+++ b/packages/vue-component/plugin/dev-server.js
@@ -50,7 +50,9 @@ if(Meteor.isDevelopment) {
 
   try {
     server.listen(PORT);
-    process.stdout.clearLine();
+    if (process.stdout.clearLine) {
+        process.stdout.clearLine();
+    }
     process.stdout.write(`\r   [HMR] Dev server listening on port ${PORT}\n`);
     global._dev_server = io;
     global._dev_server_http = server;


### PR DESCRIPTION
As seen e.g. in
https://github.com/onury/grunt-jasmine-nodejs/issues/20 ,
process.stdout.clearLine doesn't exist when standard output is not a
tty (as is the case when e.g. running inside an IDE).