### PR TITLE
basic support for css modules via <style module>

### DIFF
--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -27,6 +27,7 @@ Package.registerBuildPlugin({
   npmDependencies: {
     'postcss': '5.0.21',
     'postcss-selector-parser': '2.0.0',
+    'postcss-modules': '0.6.4',
     'socket.io': '1.4.6',
     'async': '1.4.0',
     'lodash': '4.13.1',

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -293,7 +293,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
         // Postcss
         let plugins = [];
         let postcssOptions = {
-          form: inputFilePath,
+          from: inputFilePath,
           to: inputFilePath,
           map: {
             inline: false,

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -610,7 +610,8 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
   // CSS Modules
   if(compileResult.cssModules) {
     console.log('adding css modules', JSON.stringify(compileResult.cssModules))
-    const modulesCode = `__vue_options__.computed = {\n $style: function() {\n return ${JSON.stringify(compileResult.cssModules)}\n }\n};\n`;
+    const modulesCode = '__vue_options__.computed = __vue_options__.computed || {};\n' +
+     `__vue_options__.computed.$style = function() {\n return ${JSON.stringify(compileResult.cssModules)}\n};\n`;
     js += modulesCode;
     console.log(modulesCode)
   }

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -607,6 +607,14 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
     js += `__vue_options__._scopeId = '${vueId}';`;
   }
 
+  // CSS Modules
+  if(compileResult.cssModules) {
+    console.log('adding css modules', JSON.stringify(compileResult.cssModules))
+    const modulesCode = `__vue_options__.computed = {\n $style: function() {\n return ${JSON.stringify(compileResult.cssModules)}\n }\n};\n`;
+    js += modulesCode;
+    console.log(modulesCode)
+  }
+
   // Package context
   js += `__vue_options__.packageName = '${inputFile.getPackageName()}';`;
 


### PR DESCRIPTION
This adds support for CSS modules following the implementation used by [vue-loader](https://github.com/vuejs/vue-loader/).
To use CSS modules, you add the `module` attribute to your style tag:
``` css
<style module>
.test {
  color: red;
}
</style>
``` 
Then you reference it via the `$style` computed property:
``` js
<div :class="$style.test">Hello!</div>
```

I also fixed a typo on the postcss call ("form" -> "from") since I needed the full path... and then I of course had a typo in that commit message. 😊 

This does not include support for composing from other CSS modules files, since to do that we have to call back to the compiler and either pull the file from cache or compile it on the fly and return the result. We would also have to pull in other file types on demand and process them (composing from say a `.scss` file).
Composing from global works, of course, since that doesn't require us to load those files.