### PR TITLE
update vue-server-renderer from 2.6.10 to 2.6.12 Fix Version mismatch 

### DIFF
--- a/packages/vue-ssr/package.js
+++ b/packages/vue-ssr/package.js
@@ -28,6 +28,6 @@ Package.onUse(function (api) {
 })
 
 Npm.depends({
-  'vue-server-renderer': '2.6.10',
+  'vue-server-renderer': '2.6.12',
   'cookie-parser': '1.4.4',
 })


### PR DESCRIPTION
This fixes the following error I had while deploying to galaxy

`
2020-10-20 15:21:34+02:00Error: v652h
2020-10-20 15:21:34+02:00v652h
2020-10-20 15:21:34+02:00Vue packages version mismatch:v652h
2020-10-20 15:21:34+02:00v652h
2020-10-20 15:21:34+02:00- vue@2.6.12v652h
2020-10-20 15:21:34+02:00- vue-server-renderer@2.6.10
`

