### PR TITLE
update the default JS tag handler check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## This package is just temporary as fix for my apps in meteor 2.12 and vue2. It wont be maintained once its fixed upstream. 
+
 <p align="center"><img src="https://github.com/Akryum/vue-meteor/raw/master/vue%2Bmeteor.png"></p>
 
 <p align="center">

--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -1,6 +1,6 @@
 Package.describe({
-  name: 'akryum:vue-component',
-  version: '0.16.0',
+  name: 'bslocombe:vue-component',
+  version: '0.16.1',
   summary: 'VueJS single-file components that hot-reloads',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md',

--- a/packages/vue-component/package.js
+++ b/packages/vue-component/package.js
@@ -23,8 +23,8 @@ Package.registerBuildPlugin({
     'plugin/plugin.js',
   ],
   npmDependencies: {
-    'postcss': '7.0.16',
-    'postcss-load-config': '2.0.0',
+    "postcss": "8.4.33",
+    "postcss-load-config": "6.0.1",
     'postcss-selector-parser': '2.2.3',
     'postcss-modules': '1.4.1',
     'socket.io': '2.2.0',

--- a/packages/vue-component/plugin/post-css.js
+++ b/packages/vue-component/plugin/post-css.js
@@ -23,12 +23,12 @@ loadPostcssConfig = Meteor.wrapAsync(function (cb) {
   }
 
   loaded.then(config => {
-    let plugins = []
+    let plugins = {}
     let options = {}
 
     // merge postcss config file
     if (config && config.plugins) {
-      plugins = plugins.concat(config.plugins)
+      plugins = {...plugins, ...config.plugins}
     }
     if (config && config.options) {
       options = Object.assign({}, config.options, options)

--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -79,7 +79,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       }
       
       // Lang
-      if (sfcBlock.lang !== undefined) {
+      if (sfcBlock.lang !== undefined && sfcBlock.lang !== 'js') {
         let lang = sfcBlock.lang
         try {
           let compile = global.vue.lang[lang]


### PR DESCRIPTION
#437 This is my hack to work around the "Can't find handler for lang 'js', did you install it?" error for vue2 projects. 